### PR TITLE
Add `UPGrad`

### DIFF
--- a/LibMTL/config.py
+++ b/LibMTL/config.py
@@ -78,6 +78,11 @@ _parser.add_argument('--MoDo_rho', type=float, default=0.1, help=' ')
 ## SDMGrad
 _parser.add_argument('--SDMGrad_lamda', type=float, default=0.3, help=' ')
 _parser.add_argument('--SDMGrad_niter', type=int, default=20, help=' ')
+## UPGrad
+_parser.add_argument('--UPGrad_norm_eps', type=float, default=0.0001,
+                     help='A small value to avoid division by zero when normalizing.')
+_parser.add_argument('--UPGrad_reg_eps', type=float, default=0.0001,
+                     help='A small value to add to the diagonal of the gramian to make it positive definite.')
 
 #### bilevel methods
 _parser.add_argument('--outer_lr', type=float, default=1e-3, help='outer lr')
@@ -107,7 +112,7 @@ def prepare_args(params):
     if params.weighting in ['EW', 'UW', 'GradNorm', 'GLS', 'RLW', 'MGDA', 'IMTL',
                             'PCGrad', 'GradVac', 'CAGrad', 'GradDrop', 'DWA', 
                             'Nash_MTL', 'MoCo', 'Aligned_MTL', 'DB_MTL', 'STCH', 
-                            'ExcessMTL', 'FairGrad', 'FAMO', 'MoDo', 'SDMGrad']:
+                            'ExcessMTL', 'FairGrad', 'FAMO', 'MoDo', 'SDMGrad', 'UPGrad']:
         if params.weighting in ['DWA']:
             if params.T is not None:
                 kwargs['weight_args']['T'] = params.T
@@ -175,6 +180,9 @@ def prepare_args(params):
         elif params.weighting in ['SDMGrad']:
             kwargs['weight_args']['SDMGrad_lamda'] = params.SDMGrad_lamda
             kwargs['weight_args']['SDMGrad_niter'] = params.SDMGrad_niter
+        elif params.weighting in ['UPGrad']:
+            kwargs['weight_args']['UPGrad_norm_eps'] = params.UPGrad_norm_eps
+            kwargs['weight_args']['UPGrad_reg_eps'] = params.UPGrad_reg_eps
     elif params.weighting in ['MOML', 'FORUM', 'AutoLambda']:
         kwargs['weight_args']['outer_lr'] = params.outer_lr
         kwargs['weight_args']['inner_step'] = params.inner_step

--- a/LibMTL/weighting/UPGrad.py
+++ b/LibMTL/weighting/UPGrad.py
@@ -1,0 +1,155 @@
+# The code of this file was partly taken from https://github.com/TorchJD/torchjd.
+# It is therefore also subject to the following license:
+#
+# MIT License
+#
+# Copyright (c) Valérian Rey, Pierre Quinton
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import numpy as np
+import torch
+from qpsolvers import solve_qp
+from torch import Tensor
+
+from LibMTL.weighting.abstract_weighting import AbsWeighting
+
+
+class UPGrad(AbsWeighting):
+    r"""Unconflicting Projection of Gradients (UPGrad).
+    
+    This method is proposed in `Jacobian Descent for Multi-Objective Optimization <https://arxiv.org/pdf/2406.16232>`_
+    and implemented by adapting from the `official TorchJD implementation <https://github.com/TorchJD/torchjd>`_.
+    """
+
+    def __init__(self):
+        super().__init__()
+        
+    def backward(self, losses, **kwargs):
+        norm_eps = kwargs['UPGrad_norm_eps']
+        reg_eps = kwargs['UPGrad_reg_eps']
+
+        if self.rep_grad:
+            raise ValueError('No support for method UPGrad with representation gradients (rep_grad=True)')
+        else:
+            self._compute_grad_dim()
+            grads = self._compute_grad(losses, mode='backward')
+
+        # Compute the weights corresponding to UPGrad
+        pref_vector = torch.ones(len(grads), device=grads.device, dtype=grads.dtype) / len(grads)
+        U = torch.diag(pref_vector)
+        G = _regularize(_normalize(_compute_gramian(grads), norm_eps), reg_eps)
+        W = _project_weights(U, G)
+        weights = torch.sum(W, dim=0)
+
+        # Store in the .grad fields the weighted sum of the gradients
+        self._backward_new_grads(weights, grads=grads)
+
+        # Return the weights as a numpy vector
+        return weights.detach().cpu().numpy()
+
+
+def _compute_gramian(matrix: Tensor) -> Tensor:
+    """
+    Computes the `Gramian matrix <https://en.wikipedia.org/wiki/Gram_matrix>`_ of a given matrix.
+    """
+
+    return matrix @ matrix.T
+
+
+def _normalize(gramian: Tensor, eps: float) -> Tensor:
+    """
+    Normalizes the gramian `G=AA^T` with respect to the Frobenius norm of `A`.
+
+    If `G=A A^T`, then the Frobenius norm of `A` is the square root of the trace of `G`, i.e., the
+    sqrt of the sum of the diagonal elements. The gramian of the (Frobenius) normalization of `A` is
+    therefore `G` divided by the sum of its diagonal elements.
+    """
+    squared_frobenius_norm = gramian.diagonal().sum()
+    if squared_frobenius_norm < eps:
+        return torch.zeros_like(gramian)
+    else:
+        return gramian / squared_frobenius_norm
+
+
+def _regularize(gramian: Tensor, eps: float) -> Tensor:
+    """
+    Adds a regularization term to the gramian to enforce positive definiteness.
+
+    Because of numerical errors, `gramian` might have slightly negative eigenvalue(s). Adding a
+    regularization term which is a small proportion of the identity matrix ensures that the gramian
+    is positive definite.
+    """
+
+    regularization_matrix = eps * torch.eye(gramian.shape[0], dtype=gramian.dtype, device=gramian.device)
+    return gramian + regularization_matrix
+
+
+def _project_weights(U: Tensor, G: Tensor) -> Tensor:
+    """
+    Computes the tensor of weights corresponding to the projection of the vectors in `U` onto the
+    rows of a matrix whose Gramian is provided.
+
+    :param U: The tensor of weights corresponding to the vectors to project, of shape `[..., m]`.
+    :param G: The Gramian matrix of shape `[m, m]`. It must be symmetric and positive definite.
+    :param solver: The quadratic programming solver to use.
+    :return: A tensor of projection weights with the same shape as `U`.
+    """
+
+    G_ = _to_array(G)
+    U_ = _to_array(U)
+
+    W = np.apply_along_axis(lambda u: _project_weight_vector(u, G_), axis=-1, arr=U_)
+
+    return torch.as_tensor(W, device=G.device, dtype=G.dtype)
+
+
+def _project_weight_vector(u: np.ndarray, G: np.ndarray) -> np.ndarray:
+    r"""
+    Computes the weights `w` of the projection of `J^T u` onto the dual cone of the rows of `J`,
+    given `G = J J^T` and `u`. In other words, this computes the `w` that satisfies
+    `\pi_J(J^T u) = J^T w`, with `\pi_J` defined in Equation 3 of [1].
+
+    By Proposition 1 of [1], this is equivalent to solving for `v` the following quadratic program:
+    minimize        v^T G v
+    subject to      u \preceq v
+
+    Reference:
+    [1] `Jacobian Descent For Multi-Objective Optimization <https://arxiv.org/pdf/2406.16232>`_.
+
+    :param u: The vector of weights `u` of shape `[m]` corresponding to the vector `J^T u` to
+        project.
+    :param G: The Gramian matrix of `J`, equal to `J J^T`, and of shape `[m, m]`. It must be
+        symmetric and positive definite.
+    :param solver: The quadratic programming solver to use.
+    """
+
+    m = G.shape[0]
+    w = solve_qp(G, np.zeros(m), -np.eye(m), -u, solver="quadprog")
+
+    if w is None:  # This may happen when G has large values.
+        raise ValueError("Failed to solve the quadratic programming problem.")
+
+    return w
+
+
+def _to_array(tensor: Tensor) -> np.ndarray:
+    """Transforms a tensor into a numpy array with float64 dtype."""
+
+    return tensor.cpu().detach().numpy().astype(np.float64)

--- a/LibMTL/weighting/__init__.py
+++ b/LibMTL/weighting/__init__.py
@@ -21,6 +21,7 @@ from LibMTL.weighting.FairGrad import FairGrad
 from LibMTL.weighting.FAMO import FAMO
 from LibMTL.weighting.MoDo import MoDo
 from LibMTL.weighting.SDMGrad import SDMGrad
+from LibMTL.weighting.UPGrad import UPGrad
 
 __all__ = ['AbsWeighting',
            'EW', 
@@ -44,4 +45,5 @@ __all__ = ['AbsWeighting',
            'FairGrad',
            'FAMO',
            'MoDo',
-           'SDMGrad']
+           'SDMGrad',
+           'UPGrad']

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 ## News
 
+- **[Apr 21 2025]** Added support for [UPGrad](https://arxiv.org/pdf/2406.16232).
 - **[Feb 18 2025]** Added support for a bilevel method [Auto-Lambda](https://openreview.net/forum?id=KKeCMim5VN) (TMLR 2022).
 - **[Feb 17 2025]** Added support for [FAMO](https://openreview.net/forum?id=zMeemcUeXL) (NeurIPS 2023), [SDMGrad](https://openreview.net/forum?id=4Ks8RPcXd9) (NeurIPS 2023), and [MoDo](https://openreview.net/forum?id=yPkbdJxQ0o) (NeurIPS 2023; JMLR 2024).
 - **[Feb 06 2025]** Added support for two bilevel methods: [MOML](https://proceedings.neurips.cc/paper/2021/hash/b23975176653284f1f7356ba5539cfcb-Abstract.html) (NeurIPS 2021; AIJ 2024), [FORUM](https://ebooks.iospress.nl/doi/10.3233/FAIA240793) (ECAI 2024).
@@ -84,6 +85,7 @@ Each module is introduced in [Docs](https://libmtl.readthedocs.io/en/latest/docs
 | [ExcessMTL](https://openreview.net/forum?id=JzWFmMySpn) ([official code](https://github.com/yifei-he/ExcessMTL/blob/main/LibMTL/LibMTL/weighting/ExcessMTL.py))                                                   | ICML 2024          | ``--weighting ExcessMTL``   |
 | [FairGrad](https://openreview.net/forum?id=KLmWRMg6nL) ([official code](https://github.com/OptMN-Lab/fairgrad))                                                                                                   | ICML 2024          | ``--weighting FairGrad``    |
 | [DB-MTL](https://arxiv.org/abs/2308.12029)                                                                                                                                                                        | arXiv              | ``--weighting DB_MTL``      |
+| [UPGrad](https://arxiv.org/pdf/2406.16232) ([official code](https://github.com/TorchJD/torchjd))                                                                                                                  | arXiv              | ``--weighting UPGrad``      |
 
 | Architectures                                                                                                                                                                                                          | Venues          | Arguments                      |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ------------------------------ |

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@ osqp==0.6.3
 Pillow==10.1.0
 pybind11==2.11.1
 qdldl==0.1.7.post0
+qpsolvers==4.6.0
+quadprog==0.1.12
 scipy==1.10.1
 scs==3.2.3
 torch==1.8.1+cu111


### PR DESCRIPTION
This PR adds support for another weighting method that we have developed with my colleague Pierre. It is called UPGrad (Unconflicting Projection of Gradients), and was proposed in our paper [Jacobian Descent for Multi-Objective Optimization](https://arxiv.org/pdf/2406.16232). To implement it, I just adapted our [official implementation](https://github.com/TorchJD/torchjd/blob/main/src/torchjd/aggregation/upgrad.py) from TorchJD.

I tested it on NYUv2 with:
```
python main.py --weighting UPGrad --arch HPS --dataset_path ./ --gpu_id 0 --scheduler step --mode train --save_path ./results --train_bs=4 --test_bs=2 --epochs=1
```
and it worked at a similar speed to that of MGDA and other methods.

Since this method depends on `quadprog` (a quadratic programming solver), and on `qpsolvers` (a library proposing a common interface for quadratic programming solvers), I added them to `requirements.txt`. I didn't want to follow what was done with `NashMTL` (a conditional pip install in the python code, if the import fails), because that seems to be deprecated and apparently pip will disable this possibility in the future. From my experience with them, these libraries are very stable and rarely have any issue, especially if we fix their version. So I hope this works for you! 

Please tell me if I'm forgetting anything!

Thanks for your time!